### PR TITLE
Feature/mode button changes

### DIFF
--- a/lib/hardware/button.cpp
+++ b/lib/hardware/button.cpp
@@ -4,7 +4,7 @@
 
 volatile uint32_t temp = 0;
 
-void IRAM_ATTR buttonTrigger(void* arg) {
+void buttonTrigger(void* arg) {
   if(!arg) {
     return;
   }
@@ -46,7 +46,7 @@ bool Button::currently_pressed() const {
   return _current_state;
 }
 
-bool IRAM_ATTR Button::state_changed(int state) {
+bool Button::state_changed(int state) {
   bool read_state = state == _pull_type_mode;
   if(_last_state_change + DEBOUNCE_TIME_MILLIS > millis() || read_state == _current_state) {
     return false;
@@ -67,7 +67,7 @@ bool IRAM_ATTR Button::state_changed(int state) {
   return true;
 }
 
-uint8_t IRAM_ATTR Button::get_pin() const {
+uint8_t Button::get_pin() const {
   return _pin;
 }
 

--- a/lib/hardware/button.cpp
+++ b/lib/hardware/button.cpp
@@ -1,5 +1,3 @@
-#include <soc/soc.h>
-
 #include "button.h"
 
 volatile uint32_t temp = 0;
@@ -24,18 +22,23 @@ Button::Button(uint8_t pin, uint8_t pull_type) :
     _on_button_pressed_fn(nullptr) {
 
   gpio_config_t io_conf;
-  io_conf.intr_type = (gpio_int_type_t)GPIO_PIN_INTR_DISABLE;
+  io_conf.intr_type = (gpio_int_type_t) GPIO_PIN_INTR_DISABLE;
   io_conf.mode = GPIO_MODE_INPUT;
   io_conf.pin_bit_mask = 1ULL << pin;
-  io_conf.pull_down_en = pull_type == PULLDOWN ? (gpio_pulldown_t)1 : (gpio_pulldown_t)0;
-  io_conf.pull_up_en = pull_type == PULLUP ? (gpio_pullup_t)1 : (gpio_pullup_t)0;
+  io_conf.pull_down_en = pull_type == PULLDOWN ? (gpio_pulldown_t) 1 : (gpio_pulldown_t) 0;
+  io_conf.pull_up_en = pull_type == PULLUP ? (gpio_pullup_t) 1 : (gpio_pullup_t) 0;
   gpio_config(&io_conf);
 
-  gpio_set_intr_type((gpio_num_t)pin, GPIO_INTR_ANYEDGE);
+  gpio_set_intr_type((gpio_num_t) pin, GPIO_INTR_ANYEDGE);
   gpio_install_isr_service(0);
-  gpio_isr_handler_add((gpio_num_t)pin, buttonTrigger, this);
-//  esp_intr_alloc(ETS_GPIO_INTR_SOURCE, ESP_INTR_FLAG_LEVEL3, buttonTrigger, this, nullptr);
+  gpio_isr_handler_add((gpio_num_t) pin, buttonTrigger, this);
   _current_state = digitalRead(_pin) == _pull_type_mode;
+}
+
+Button::~Button() {
+  gpio_reset_pin((gpio_num_t) _pin);
+  gpio_isr_handler_remove((gpio_num_t) _pin);
+  gpio_uninstall_isr_service();
 }
 
 void Button::set_observer(ButtonObserver* observer) {

--- a/lib/hardware/button.h
+++ b/lib/hardware/button.h
@@ -18,7 +18,7 @@ class Button {
   typedef void(*on_button_pressed_fn_t)(Button*, uint32_t);
 
 
-  Button(uint8_t pin, uint8_t pull_type = PULLDOWN);
+  Button(uint8_t pin, uint8_t pull_type = PULLUP);
   virtual ~Button() = default;
 
   /**

--- a/lib/hardware/button.h
+++ b/lib/hardware/button.h
@@ -19,7 +19,7 @@ class Button {
 
 
   Button(uint8_t pin, uint8_t pull_type = PULLUP);
-  virtual ~Button() = default;
+  virtual ~Button();
 
   /**
    * Let the button know that the state has changed

--- a/lib/hardware/button_observer.h
+++ b/lib/hardware/button_observer.h
@@ -17,7 +17,7 @@ class ButtonObserver {
    * if button is PULLDOWN, triggers when  LOW -> HIGH
    * @param button: The button that caused the trigger
    */
-  virtual void IRAM_ATTR on_button_down(Button* button) {/*no implementation*/};
+  virtual void on_button_down(Button* button) {/*no implementation*/};
 
   /**
    * Callback when the button is released
@@ -25,7 +25,7 @@ class ButtonObserver {
    * if button is PULLDOWN, triggers when HIGH -> LOW
    * @param button: The button that caused the trigger
    */
-  virtual void IRAM_ATTR on_button_release(Button* button) {/*no implementation*/};
+  virtual void on_button_release(Button* button) {/*no implementation*/};
 
   /**
    *
@@ -35,7 +35,7 @@ class ButtonObserver {
    * @param button: The button that caused the trigger
    * @param millis: how long the button was pressed in millis
    */
-  virtual void IRAM_ATTR on_button_pressed(Button* button, uint32_t millis) {/*no implementation*/};
+  virtual void on_button_pressed(Button* button, uint32_t millis) {/*no implementation*/};
 };
 
 #endif //BGEIGIE_POINTCAST_BUTTONOBSERVER_H

--- a/lib/utils/circular_buffer.h
+++ b/lib/utils/circular_buffer.h
@@ -34,7 +34,7 @@ class CircularBuffer {
    * Add a value to the buffer. If the buffer is full, it will throw away the oldest value and add this.
    * @param val
    */
-  void IRAM_ATTR add(T val) {
+  void add(T val) {
     buffer[(current + count) % max] = val;
     if(count < max) {
       ++count;

--- a/src/api_connector.cpp
+++ b/src/api_connector.cpp
@@ -10,7 +10,7 @@ ApiConnector::ApiConnector(EspConfig& config) :
     merged_reading() {
 }
 
-bool ApiConnector::start_connect() {
+bool ApiConnector::start_connect(bool initial) {
   if(is_connected()) {
     return true;
   }
@@ -22,8 +22,11 @@ bool ApiConnector::start_connect() {
 
   config.get_wifi_password(password) ? WiFi.begin(ssid, password) : WiFi.begin(ssid);
 
-  merged_reading.reset();
-  last_send = millis();
+  if(initial) {
+    merged_reading.reset();
+    last_send = millis();
+  }
+
   return is_connected();
 }
 

--- a/src/api_connector.h
+++ b/src/api_connector.h
@@ -19,10 +19,12 @@ class ApiConnector {
   virtual ~ApiConnector() = default;
 
   /**
+   *
    * Initialize the connection
+   * @param initial: set to false if its for reconnect / connect in error
    * @return true if connection with the wifi was made
    */
-  bool start_connect();
+  bool start_connect(bool initial = true);
 
   /**
    * Disconnect

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -24,7 +24,7 @@ void Controller::initialize() {
   schedule_event(Event_enum::e_controller_initialized);
 }
 
-void IRAM_ATTR Controller::on_button_pressed(Button* button, uint32_t millis_pressed) {
+void Controller::on_button_pressed(Button* button, uint32_t millis_pressed) {
   if(button->get_pin() == MODE_BUTTON_PIN) {
     if(millis_pressed > 4000) {
       schedule_event(Event_enum::e_button_long_pressed);

--- a/src/state_led.cpp
+++ b/src/state_led.cpp
@@ -4,12 +4,13 @@
 
 StateLED::StateLED() :
     RGBLed(RGB_LED_PIN_R, RGB_LED_PIN_G, RGB_LED_PIN_B),
+    blink_state(false),
     _rgb_off{0, 0, 0},
     _rgb_init{50, 50, 50},
     _rgb_config{255, 0, 255},
     _rgb_mobile{0, 0, 255},
-    _rgb_stationary_connecting{0, 0, 255},
-    _rgb_stationary_active{0, 0, 255},
+    _rgb_stationary_connecting{0, 255, 0},
+    _rgb_stationary_active{0, 255, 0},
     _rgb_stationary_error{255, 0, 0} {
 }
 
@@ -37,5 +38,15 @@ void StateLED::set_state_led(StateLED::StateColor color) {
     case stationary_error:
       set(_rgb_stationary_error);
       break;
+  }
+}
+void StateLED::blink(StateLED::StateColor color, uint32_t frequency) {
+  // Blink LED
+  if(millis() % frequency > frequency / 2 && !blink_state) {
+    set_state_led(color);
+    blink_state = true;
+  } else if(millis() % frequency < frequency / 2 && blink_state){
+    set_state_led(StateLED::StateColor::off);
+    blink_state = false;
   }
 }

--- a/src/state_led.h
+++ b/src/state_led.h
@@ -22,7 +22,10 @@ class StateLED : private RGBLed{
 
   void set_state_led(StateColor);
 
+  void blink(StateColor color, uint32_t frequency);
+
  private:
+  bool blink_state;
   RGB _rgb_off;
   RGB _rgb_init;
   RGB _rgb_config;

--- a/src/state_machine/context.cpp
+++ b/src/state_machine/context.cpp
@@ -29,7 +29,7 @@ void Context::run() {
   handle_events();
 }
 
-void IRAM_ATTR Context::schedule_event(Event_enum event_id) {
+void Context::schedule_event(Event_enum event_id) {
   _event_queue.add(event_id);
 }
 

--- a/src/state_machine/events.h
+++ b/src/state_machine/events.h
@@ -6,6 +6,7 @@ typedef enum {
   e_button_pressed,
   e_button_long_pressed,
   e_controller_initialized,
+  e_post_init_time_passed,
   e_server_initialized,
   e_start_stationary,
   e_connected,

--- a/src/state_machine/states/InitializeState.cpp
+++ b/src/state_machine/states/InitializeState.cpp
@@ -1,6 +1,5 @@
-#include "active_states/MobileModeState.h"
 #include "InitializeState.h"
-#include "SetupServerState.hpp"
+#include "PostInitializeState.h"
 
 InitializeState::InitializeState(Controller& context) : State(context) {
 }
@@ -21,11 +20,7 @@ void InitializeState::exit_action() {
 void InitializeState::handle_event(Event_enum event_id) {
   switch(event_id) {
     case e_controller_initialized: {
-      if(controller.get_mode_button().currently_pressed()) {
-        controller.set_state(new SetupServerState(controller));
-      } else {
-        controller.set_state(new MobileModeState(controller));
-      }
+      controller.set_state(new PostInitializeState(controller));
       break;
     }
     default:

--- a/src/state_machine/states/PostInitializeState.cpp
+++ b/src/state_machine/states/PostInitializeState.cpp
@@ -1,0 +1,41 @@
+#include "PostInitializeState.h"
+#include "SetupServerState.hpp"
+#include "active_states/MobileModeState.h"
+
+#define POST_INIT_DURATION_MILLIS 3000
+
+PostInitializeState::PostInitializeState(Controller& context) : State(context), timer(0) {
+}
+
+void PostInitializeState::entry_action() {
+  debug_println("Entered state PostInitialize");
+  controller.get_state_led().set_state_led(StateLED::StateColor::init);
+  timer = millis();
+}
+
+void PostInitializeState::do_activity() {
+  if(millis() > timer + POST_INIT_DURATION_MILLIS) {
+    controller.schedule_event(e_post_init_time_passed);
+  }
+}
+
+void PostInitializeState::exit_action() {
+
+}
+
+void PostInitializeState::handle_event(Event_enum event_id) {
+  switch(event_id) {
+    case e_button_pressed: {
+      controller.set_state(new SetupServerState(controller));
+      break;
+    }
+    case e_post_init_time_passed: {
+      controller.set_state(new MobileModeState(controller));
+      break;
+    }
+    default:
+      State::handle_event(event_id);
+      break;
+  }
+}
+

--- a/src/state_machine/states/PostInitializeState.h
+++ b/src/state_machine/states/PostInitializeState.h
@@ -1,0 +1,21 @@
+#ifndef BGEIGIE_POINTCAST_POSTINITIALIZESTATE_H
+#define BGEIGIE_POINTCAST_POSTINITIALIZESTATE_H
+
+#include "state.h"
+
+class PostInitializeState: public State {
+ public:
+  PostInitializeState(Controller& context);
+  virtual ~PostInitializeState() = default;
+
+  void entry_action() override;
+  void do_activity() override;
+  void exit_action() override;
+  void handle_event(Event_enum event_id) override;
+
+ private:
+
+  uint32_t timer;
+};
+
+#endif //BGEIGIE_POINTCAST_POSTINITIALIZESTATE_H

--- a/src/state_machine/states/active_states/stationary_mode_states/ConnectingState.cpp
+++ b/src/state_machine/states/active_states/stationary_mode_states/ConnectingState.cpp
@@ -2,6 +2,8 @@
 #include "TestApiState.h"
 #include "ConnectionErrorState.h"
 
+#define CONNECTING_BLINK_FREQUENCY_MILLIS 500
+
 ConnectingState::ConnectingState(Controller& context): StationaryModeState(context), timer(0) {
 }
 
@@ -20,6 +22,8 @@ void ConnectingState::do_activity() {
   else if (millis() > timer + MILLIS_BEFORE_CONNECTION_FAILURE) {
     controller.schedule_event(e_connection_failed);
   }
+
+  controller.get_state_led().blink(StateLED::StateColor::stationary_connecting, CONNECTING_BLINK_FREQUENCY_MILLIS);
 }
 
 void ConnectingState::exit_action() {

--- a/src/state_machine/states/active_states/stationary_mode_states/ConnectionErrorState.cpp
+++ b/src/state_machine/states/active_states/stationary_mode_states/ConnectionErrorState.cpp
@@ -1,7 +1,7 @@
 #include "ConnectionErrorState.h"
 #include "TestApiState.h"
 
-#define BLINK_FREQUENCY_MILLIS 500
+#define BLINK_FREQUENCY_MILLIS 1000
 
 ConnectionErrorState::ConnectionErrorState(Controller& context) : StationaryModeState(context), timer(0), blink_state(false) {
 }
@@ -14,17 +14,11 @@ void ConnectionErrorState::entry_action() {
 
 void ConnectionErrorState::do_activity() {
   StationaryModeState::do_activity();
-  if(!((millis() - timer) % 5000) && controller.get_api_connector().start_connect()) {
+  if(!((millis() - timer) % 5000) && controller.get_api_connector().start_connect(false)) {
     controller.schedule_event(Event_enum::e_connected);
   }
-  // Blink LED
-  if(millis() % BLINK_FREQUENCY_MILLIS > BLINK_FREQUENCY_MILLIS / 2 && !blink_state) {
-    controller.get_state_led().set_state_led(StateLED::StateColor::stationary_error);
-    blink_state = true;
-  } else if(millis() % BLINK_FREQUENCY_MILLIS < BLINK_FREQUENCY_MILLIS / 2 && blink_state){
-    controller.get_state_led().set_state_led(StateLED::StateColor::off);
-    blink_state = false;
-  }
+
+  controller.get_state_led().blink(StateLED::StateColor::stationary_error, BLINK_FREQUENCY_MILLIS);
 }
 
 void ConnectionErrorState::exit_action() {

--- a/src/state_machine/states/active_states/stationary_mode_states/ConnectionErrorState.cpp
+++ b/src/state_machine/states/active_states/stationary_mode_states/ConnectionErrorState.cpp
@@ -18,11 +18,12 @@ void ConnectionErrorState::do_activity() {
     controller.schedule_event(Event_enum::e_connected);
   }
   // Blink LED
-  if(timer % BLINK_FREQUENCY_MILLIS > BLINK_FREQUENCY_MILLIS / 2 && !blink_state) {
+  if(millis() % BLINK_FREQUENCY_MILLIS > BLINK_FREQUENCY_MILLIS / 2 && !blink_state) {
     controller.get_state_led().set_state_led(StateLED::StateColor::stationary_error);
     blink_state = true;
-  } else if(timer % BLINK_FREQUENCY_MILLIS < BLINK_FREQUENCY_MILLIS / 2 && blink_state){
+  } else if(millis() % BLINK_FREQUENCY_MILLIS < BLINK_FREQUENCY_MILLIS / 2 && blink_state){
     controller.get_state_led().set_state_led(StateLED::StateColor::off);
+    blink_state = false;
   }
 }
 

--- a/test/test_libs/test_button.cpp
+++ b/test/test_libs/test_button.cpp
@@ -75,7 +75,7 @@ void test_button() {
   TEST_ASSERT_FALSE(fn_button_released);
   TEST_ASSERT_FALSE(fn_button_pressed);
 
-  TEST_ASSERT_TRUE(test_button.state_changed(HIGH));
+  TEST_ASSERT_TRUE(test_button.state_changed(LOW));
 
   TEST_ASSERT_TRUE(test_button.currently_pressed());
 
@@ -88,8 +88,8 @@ void test_button() {
   TEST_ASSERT_FALSE(fn_button_pressed);
 
   // Debounce timer should ignore this
-  TEST_ASSERT_FALSE(test_button.state_changed(LOW));
   TEST_ASSERT_FALSE(test_button.state_changed(HIGH));
+  TEST_ASSERT_FALSE(test_button.state_changed(LOW));
 
   TEST_ASSERT_TRUE(button_down);
   TEST_ASSERT_FALSE(button_released);
@@ -104,7 +104,7 @@ void test_button() {
   // Delay for debounce
   delay(wait_time);
 
-  test_button.state_changed(LOW);
+  test_button.state_changed(HIGH);
 
   TEST_ASSERT_FALSE(test_button.currently_pressed());
 

--- a/test/test_state_machine/controller_init.cpp
+++ b/test/test_state_machine/controller_init.cpp
@@ -1,7 +1,7 @@
 #include <unity.h>
 #include <controller.h>
 #include <state_machine/states/InitializeState.h>
-#include <state_machine/states/active_states/MobileModeState.h>
+#include <state_machine/states/PostInitializeState.h>
 
 /**
  * Test controller initial state transition
@@ -17,5 +17,5 @@ void controller_init(void) {
 
   controller.run();
 
-  TEST_ASSERT_NOT_NULL(dynamic_cast<MobileModeState*>(controller.get_current_state()));
+  TEST_ASSERT_NOT_NULL(dynamic_cast<PostInitializeState*>(controller.get_current_state()));
 }

--- a/test/test_state_machine/controller_state_transitions.cpp
+++ b/test/test_state_machine/controller_state_transitions.cpp
@@ -2,6 +2,7 @@
 #include <unity.h>
 #include <controller.h>
 #include <state_machine/states/InitializeState.h>
+#include <state_machine/states/PostInitializeState.h>
 #include <state_machine/states/SetupServerState.hpp>
 #include <state_machine/states/ServerActiveState.hpp>
 #include <state_machine/states/active_states/MobileModeState.h>
@@ -12,106 +13,132 @@
 #include <state_machine/states/active_states/stationary_mode_states/TestApiState.h>
 
 /**
- * Test controller state transition to start AP server
+ * Test controller state transition: Init -> MobileMode
  */
-void controller_state_transitions(void) {
-  {
-    // Init -> MobileMode
-    Controller controller;
+void controller_state_transitions_init_mobile(void) {
+  // Init -> MobileMode
+  Controller controller;
+  controller.setup_state_machine();
 
-    controller.set_state(new InitializeState(controller));
-    TEST_ASSERT_NOT_NULL(dynamic_cast<InitializeState*>(controller.get_current_state()));
+  TEST_ASSERT_NOT_NULL(dynamic_cast<InitializeState*>(controller.get_current_state()));
 
-    controller.schedule_event(Event_enum::e_controller_initialized);
-    controller.handle_events();
+  controller.schedule_event(Event_enum::e_controller_initialized);
+  controller.handle_events();
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<MobileModeState*>(controller.get_current_state()));
-  }
-  {
-    // Init -> SetupServer -> ServerActive
-    Controller controller;
+  TEST_ASSERT_NOT_NULL(dynamic_cast<PostInitializeState*>(controller.get_current_state()));
 
-    controller.set_state(new InitializeState(controller));
-    TEST_ASSERT_NOT_NULL(dynamic_cast<InitializeState*>(controller.get_current_state()));
+  controller.schedule_event(Event_enum::e_post_init_time_passed);
+  controller.handle_events();
 
-    controller.get_mode_button().state_changed(HIGH);
+  TEST_ASSERT_NOT_NULL(dynamic_cast<MobileModeState*>(controller.get_current_state()));
+}
 
-    controller.schedule_event(Event_enum::e_controller_initialized);
-    controller.handle_events();
+/**
+ * Test controller state transition: Init -> SetupServer
+ */
+void controller_state_transitions_init_server(void) {
+  // Init -> SetupServer -> ServerActive
+  Controller controller;
+  controller.setup_state_machine();
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<SetupServerState*>(controller.get_current_state()));
+  TEST_ASSERT_NOT_NULL(dynamic_cast<InitializeState*>(controller.get_current_state()));
 
-    controller.schedule_event(Event_enum::e_server_initialized);
-    controller.handle_events();
+  controller.schedule_event(Event_enum::e_controller_initialized);
+  controller.handle_events();
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<ServerActiveState*>(controller.get_current_state()));
-  }
-  {
-    // MobileMode -> StationaryMode -> MobileMode
-    Controller controller;
+  TEST_ASSERT_NOT_NULL(dynamic_cast<PostInitializeState*>(controller.get_current_state()));
 
-    controller.set_state(new MobileModeState(controller));
-    TEST_ASSERT_NOT_NULL(dynamic_cast<MobileModeState*>(controller.get_current_state()));
+  controller.schedule_event(Event_enum::e_button_pressed);
+  controller.handle_events();
 
-    controller.schedule_event(Event_enum::e_button_pressed);
-    controller.handle_events();
+  TEST_ASSERT_NOT_NULL(dynamic_cast<SetupServerState*>(controller.get_current_state()));
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<StationaryModeState*>(controller.get_current_state()));
+  controller.schedule_event(Event_enum::e_server_initialized);
+  controller.handle_events();
 
-    controller.schedule_event(Event_enum::e_button_pressed);
-    controller.handle_events();
+  TEST_ASSERT_NOT_NULL(dynamic_cast<ServerActiveState*>(controller.get_current_state()));
+}
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<MobileModeState*>(controller.get_current_state()));
-  }
-  {
-    // Connecting -> ApiTest -> Connected
-    Controller controller;
+/**
+ * Test controller state transition: MobileMode -> StationaryMode
+ */
+void controller_state_transitions_mobile_stationary(void) {
+  // MobileMode -> StationaryMode -> MobileMode
+  Controller controller;
+  controller.set_state(new MobileModeState(controller));
 
-    controller.set_state(new ConnectingState(controller));
-    TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectingState*>(controller.get_current_state()));
+  TEST_ASSERT_NOT_NULL(dynamic_cast<MobileModeState*>(controller.get_current_state()));
 
-    controller.schedule_event(Event_enum::e_connected);
-    controller.handle_events();
+  controller.schedule_event(Event_enum::e_button_pressed);
+  controller.handle_events();
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<TestApiState*>(controller.get_current_state()));
+  TEST_ASSERT_NOT_NULL(dynamic_cast<StationaryModeState*>(controller.get_current_state()));
 
-    controller.schedule_event(Event_enum::e_API_available);
-    controller.handle_events();
+  controller.schedule_event(Event_enum::e_button_pressed);
+  controller.handle_events();
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectedState*>(controller.get_current_state()));
-  }
-  {
-    // Connecting -> ConnectionError -> ApiTest -> Connected
-    Controller controller;
+  TEST_ASSERT_NOT_NULL(dynamic_cast<MobileModeState*>(controller.get_current_state()));
+}
 
-    controller.set_state(new ConnectingState(controller));
-    TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectingState*>(controller.get_current_state()));
+/**
+ * Test controller state transition: Connecting -> ApiTest
+ */
+void controller_state_transitions_connecting_test_connected(void) {
+  // Connecting -> ApiTest -> Connected
+  Controller controller;
+  controller.set_state(new ConnectingState(controller));
 
-    controller.schedule_event(Event_enum::e_connection_failed);
-    controller.handle_events();
+  TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectingState*>(controller.get_current_state()));
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectionErrorState*>(controller.get_current_state()));
+  controller.schedule_event(Event_enum::e_connected);
+  controller.handle_events();
 
-    controller.schedule_event(Event_enum::e_connected);
-    controller.handle_events();
+  TEST_ASSERT_NOT_NULL(dynamic_cast<TestApiState*>(controller.get_current_state()));
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<TestApiState*>(controller.get_current_state()));
+  controller.schedule_event(Event_enum::e_API_available);
+  controller.handle_events();
 
-    controller.schedule_event(Event_enum::e_API_available);
-    controller.handle_events();
+  TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectedState*>(controller.get_current_state()));
+}
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectedState*>(controller.get_current_state()));
-  }
-  {
-    // Connected -> ConnectionError
-    Controller controller;
+/**
+ * Test controller state transition: Connecting -> ConnectionError
+ */
+void controller_state_transitions_connecting_error_connected(void) {
+  // Connecting -> ConnectionError -> ApiTest -> Connected
+  Controller controller;
+  controller.set_state(new ConnectingState(controller));
 
-    controller.set_state(new ConnectedState(controller));
-    TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectedState*>(controller.get_current_state()));
+  TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectingState*>(controller.get_current_state()));
 
-    controller.schedule_event(Event_enum::e_connection_lost);
-    controller.handle_events();
+  controller.schedule_event(Event_enum::e_connection_failed);
+  controller.handle_events();
 
-    TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectionErrorState*>(controller.get_current_state()));
-  }
+  TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectionErrorState*>(controller.get_current_state()));
+
+  controller.schedule_event(Event_enum::e_connected);
+  controller.handle_events();
+
+  TEST_ASSERT_NOT_NULL(dynamic_cast<TestApiState*>(controller.get_current_state()));
+
+  controller.schedule_event(Event_enum::e_API_available);
+  controller.handle_events();
+
+  TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectedState*>(controller.get_current_state()));
+}
+
+/**
+ * Test controller state transition: Connected -> ConnectionError
+ */
+void controller_state_transitions_connected_error(void) {
+  // Connected -> ConnectionError
+  Controller controller;
+  controller.set_state(new ConnectedState(controller));
+
+  TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectedState*>(controller.get_current_state()));
+
+  controller.schedule_event(Event_enum::e_connection_lost);
+  controller.handle_events();
+
+  TEST_ASSERT_NOT_NULL(dynamic_cast<ConnectionErrorState*>(controller.get_current_state()));
 }

--- a/test/test_state_machine/test_controller_state.cpp
+++ b/test/test_state_machine/test_controller_state.cpp
@@ -2,7 +2,12 @@
 #include <unity.h>
 
 void controller_init(void);
-void controller_state_transitions(void);
+void controller_state_transitions_init_mobile(void);
+void controller_state_transitions_init_server(void);
+void controller_state_transitions_mobile_stationary(void);
+void controller_state_transitions_connecting_test_connected(void);
+void controller_state_transitions_connecting_error_connected(void);
+void controller_state_transitions_connected_error(void);
 
 void setup() {
   delay(2000);
@@ -11,7 +16,12 @@ void setup() {
 
   RUN_TEST(controller_init);
 
-  RUN_TEST(controller_state_transitions);
+  RUN_TEST(controller_state_transitions_init_mobile);
+  RUN_TEST(controller_state_transitions_init_server);
+  RUN_TEST(controller_state_transitions_mobile_stationary);
+  RUN_TEST(controller_state_transitions_connecting_test_connected);
+  RUN_TEST(controller_state_transitions_connecting_error_connected);
+  RUN_TEST(controller_state_transitions_connected_error);
 
   UNITY_END();
 }


### PR DESCRIPTION
* Fixed random crash on interrupt (flash access when locked)
* Add post-initial state, after startup / reset the user has 3 seconds to press the mode button to start the configuration server
* Fixed some LED colors and blinking issues
* Updated the unit tests for the new button changes / state changes

User can hold the mode button on startup to initiate the flash download (future OTA)